### PR TITLE
NSP fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "coffee --bare --compile --output lib/ src/*.litcoffee",
+    "nsp": "nsp check",
     "prepublish": "coffee --bare --compile --output lib/ src/*.litcoffee",
     "postpublish": "rm -rf lib/*",
     "test": "mocha -w -b -c --check-leaks test/suite.coffee -R progress --compilers coffee:coffee-script/register",
@@ -38,6 +39,7 @@
     "mocha": "~2"
   },
   "dependencies": {
+    "nsp": "^2.8.0",
     "request": "~2.47"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "nsp": "^2.8.0",
-    "request": "~2.47"
+    "request": "~2.81"
   }
 }


### PR DESCRIPTION
Was using an old version of request which had an NSP issue and caused packages using this dependency to not pass the NSP test.